### PR TITLE
clear datastore on manual builds (currently the only build working)

### DIFF
--- a/services/builder.js
+++ b/services/builder.js
@@ -70,6 +70,10 @@ module.exports = {
 
         console.log('Manual build starting...');
 
+        global.dataStore = {};
+
+        console.log('Erased Datastore...');
+
         build()
             .then(function () {
                 console.log('Manual build complete.');


### PR DESCRIPTION
this removes the cached data objects so the new data is represented